### PR TITLE
fix FUSE-2552 add missing configuration variable required by current …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ FuseCommon.configure do |c|
   c.airbrake_project_id = 'AIRBRAKE_PROJECT_ID'
   c.airbrake_project_key = 'AIRBRAKE_PROJECT_KEY'
   c.airbrake_environment_name = Rails.env
+  c.rails_env = Rails.env
 end
 ```
 

--- a/lib/fuse_common/configuration.rb
+++ b/lib/fuse_common/configuration.rb
@@ -1,11 +1,12 @@
 module FuseCommon
   class Configuration
-    attr_accessor :airbrake_project_id, :airbrake_project_key, :airbrake_environment_name
+    attr_accessor :airbrake_project_id, :airbrake_project_key, :airbrake_environment_name, :rails_env
 
     def initialize
       @airbrake_project_id = nil
       @airbrake_project_key = nil
       @airbrake_environment_name = Rails.env
+      @rails_env = Rails.env
     end
   end
 end


### PR DESCRIPTION
The rails_env attribute was not implemented ([here](https://github.com/Fuseit/fuse-common/pull/10/commits/e58c1959b718b668a628d7f6de90ee6438f8c778)), which resulted in issues when using the new configuration management. 

This issue does not affect other apps that are not using the new configuration feature, since it would fallback to using Figaro. 

This configuration passes in [CI](https://circleci.com/workflow-run/473df466-430f-4ac3-a6e3-ff19aeaef1b4 )