### PR TITLE
chore Bump version to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.4.0
+
+### Technical Improvements
+
+* [PLAT-1270](https://fuseuniversal.atlassian.net/browse/PLAT-1270): Chore PLAT-1270 Update airbrake dependency to 9.2.2
+* Chore Add auth token for fuse-dev-tools gem
+* Chore Fix rubocop formatting concerns
+* Chore Update Airbrake Dependency rule to allow ~> 9.0
+* Chore Fix Rubocop failure on CircleCI
+
+### Features
+
+* [FUSE-2552] (https://fuseuniversal.atlassian.net/browse/FUSE-2552): Feature FUSE-2552 Make engine configurable. Fall back to Figaro
+
+### Fix
+
+* [FUSE-2552] (https://fuseuniversal.atlassian.net/browse/FUSE-2552): Fix FUSE-2552 Add missing configuration variable required by current
+
+
 ## v0.3.0
 
 ### Technical Improvements


### PR DESCRIPTION
## Description
_Increment the fuse-common gem version to v0.4.0._

_The version in the VERSION file was changed to 0.4.0 in a previous PR. Only the changelog needed updating._