### PR TITLE
Chore TI-452 Regress some gem dependencies for compatibility

### DIFF
--- a/fuse-common.gemspec
+++ b/fuse-common.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |spec|
 
   # After updating Airbrake make sure that fuse_common/airbrake_libraries.rb is relevant
   spec.add_dependency 'airbrake', '~> 11.0.3'
-  spec.add_dependency 'figaro', '~> 1.2.0'
+  spec.add_dependency 'figaro', '~> 1.1'
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rails', '~> 4.2.11.3'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rspec', '~> 3.13.0'
+  spec.add_development_dependency 'rake', '~> 11.3'
+  spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.6.0'
   spec.add_development_dependency 'rubocop', '~> 0.65'
   spec.add_development_dependency 'rubocop-junit-formatter', '~> 0.1.4'


### PR DESCRIPTION
## Description
_Previous dependency version updates made for v1.0.0 were overconfident._

_Figaro 1.2.0 was causing an issue due to Rails <5 not being compatible with it._
_Rake 11.3.0 is currently the highest version of it used in Fusetube and I've made a safe choice to base the fuse-common Rake version on that._